### PR TITLE
AppData: Fix texts a little ambiguous to translate

### DIFF
--- a/data/iconbrowser.appdata.xml.in
+++ b/data/iconbrowser.appdata.xml.in
@@ -62,7 +62,7 @@
           <li>Add "audio-headphones" and "audio-headset"</li>
           <li>Add GitHub Actions for distribution</li>
           <li>Disable sidebar when searching</li>
-          <li>Remove freedesktop.org non-compliant app icons</li>
+          <li>Remove app icons that aren't in the freedesktop.org specification</li>
           <li>Add status emblems</li>
           <li>Mimetypes → Media Types</li>
           <li>Added French and Portuguese translations</li>

--- a/data/iconbrowser.appdata.xml.in
+++ b/data/iconbrowser.appdata.xml.in
@@ -60,7 +60,7 @@
       <description>
         <ul>
           <li>Add "audio-headphones" and "audio-headset"</li>
-          <li>Add GitHub Actions for distribution</li>
+          <li>Add "distribute-*" action icons</li>
           <li>Disable sidebar when searching</li>
           <li>Remove app icons that aren't in the freedesktop.org specification</li>
           <li>Add status emblems</li>

--- a/data/iconbrowser.appdata.xml.in
+++ b/data/iconbrowser.appdata.xml.in
@@ -59,10 +59,10 @@
     <release version="1.2.0" date="2020-07-29">
       <description>
         <ul>
-          <li>Add audio-headphones and audio-headset</li>
-          <li>Add distribute actions</li>
+          <li>Add "audio-headphones" and "audio-headset"</li>
+          <li>Add GitHub Actions for distribution</li>
           <li>Disable sidebar when searching</li>
-          <li>Remove non-fdo app names</li>
+          <li>Remove freedesktop.org non-compliant app icons</li>
           <li>Add status emblems</li>
           <li>Mimetypes → Media Types</li>
           <li>Added French and Portuguese translations</li>


### PR DESCRIPTION
- Use double quotes in audio-headphones and audio-headset to explicit for the translators that these are icon names and not intended to be translated
- Explicit what "actions" means here
- Don't abbreviate freedesktop.org which some translators who don't be accustomed to GUI programming on Liunx

This is just my opinion; feel free to suggest changes or ignore some :wink: