### PR TITLE
l10n: Setup locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,15 @@ i18n = import('i18n')
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()), language:'c')
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 gresource = gnome.compile_resources(
     'as-resources',
     'data' / 'iconbrowser.gresource.xml',
@@ -14,6 +23,7 @@ gresource = gnome.compile_resources(
 
 executable(
     meson.project_name(),
+    config_file,
     gresource,
     'src/Application.vala',
     'src/CategoryView.vala',

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -14,6 +14,11 @@ public class IconBrowser.App : Gtk.Application {
     protected override void startup () {
         base.startup ();
 
+        Intl.setlocale (LocaleCategory.ALL, "");
+        Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        Intl.textdomain (GETTEXT_PACKAGE);
+
         var quit_action = new SimpleAction ("quit", null);
 
         add_action (quit_action);

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;


### PR DESCRIPTION
We need this fix so that the app can use the translation files:

![スクリーンショット 2022-09-28 20 58 17](https://user-images.githubusercontent.com/26003928/192773525-97138c9a-3f8d-4919-b064-e7442f9236dc.png)

We're doing the similar fix in other apps e.g. https://github.com/elementary/mail/commit/a0c10837ae5bc394e63350bb14a6abcbd81197e5