### PR TITLE
Add missing `device=dri` Flatpak permission

### DIFF
--- a/io.elementary.iconbrowser.yml
+++ b/io.elementary.iconbrowser.yml
@@ -7,6 +7,7 @@ finish-args:
   - '--share=ipc'
   - '--socket=fallback-x11'
   - '--socket=wayland'
+  - '--device=dri'
 modules:
   - name: gtksourceview
     buildsystem: meson


### PR DESCRIPTION
Fix for application failing to run because of missing `device=dri` Flatpak permission

```
$ flatpak run io.elementary.iconbrowser
libEGL warning: MESA-LOADER: failed to retrieve device information

libEGL warning: DRI2: could not open /dev/dri/card0 (Нет такого файла или каталога)
libGL error: MESA-LOADER: failed to retrieve device information
No provider of glGetShaderiv found.  Requires one of:
    Desktop OpenGL 2.0
    OpenGL ES 2.0
```