### PR TITLE
Sync code snippet with selected icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 build/*
+.flatpak-builder/*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You'll need the following dependencies to build:
 * libgranite-7-dev
 * libgtk-4-dev
 * libgtksourceview-5-dev
+* libadwaita-1-dev
 * meson
 * valac
 

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,8 @@ executable(
         dependency('gobject-2.0'),
         dependency('granite-7'),
         dependency('gtk4'),
-        dependency('gtksourceview-5')
+        dependency('gtksourceview-5'),
+        dependency('libadwaita-1'),
     ],
     install : true
 )

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -13,7 +13,7 @@ public class IconView : Gtk.Box {
             icon_name: "address-book-new",
             description: _("Create a new address book"),
             category: CategoryView.Category.ACTIONS,
-            selected_icon: new IconDetails(
+            selected_icon: new IconDetails (
                 "address-book-new",
                 24
             )
@@ -155,7 +155,9 @@ public class IconView : Gtk.Box {
         notify["selected-icon"].connect (() => {
             var name = selected_icon.full_icon_name;
             var size = selected_icon.size_in_px;
-            source_buffer.text = "var icon = new Gtk.Image.from_icon_name (\"%s\") {\n    pixel_size = %d\n};".printf (name, size);
+            source_buffer.text = """var icon = new Gtk.Image.from_icon_name ("%s") {
+    pixel_size = %d
+};""".printf (name, size);
         });
     }
 
@@ -206,7 +208,7 @@ public class IconView : Gtk.Box {
                 hexpand = true
             };
 
-            var icon_and_label = new Gtk.Grid (){
+            var icon_and_label = new Gtk.Grid () {
                 row_spacing = 12,
                 valign = Gtk.Align.CENTER,
                 margin_top = 4,
@@ -243,7 +245,7 @@ public class IconDetails : Object {
     public string full_icon_name { get; construct; }
     public int size_in_px { get; construct; }
 
-    public IconDetails(string name, int size) {
+    public IconDetails (string name, int size) {
         Object (
             full_icon_name: name,
             size_in_px: size

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -217,6 +217,7 @@ public class IconView : Gtk.Box {
             icon_and_label.attach (icon, 0, 0);
             icon_and_label.attach (label, 0, 1);
             icon_btn = new Gtk.ToggleButton () {
+                valign = Gtk.Align.CENTER,
                 child = icon_and_label,
                 has_frame = false,
                 group = icon_btn
@@ -226,18 +227,21 @@ public class IconView : Gtk.Box {
                     selected_icon = new IconDetails (icon.icon_name, icon.pixel_size);
                 }
             });
-
-            row.attach (icon_btn, i, 0);
+            var icon_clamp = new Adw.Clamp () {
+                child = icon_btn,
+                maximum_size = 128
+            };
+            row.attach (icon_clamp, i, 0);
 
             i++;
         }
     }
 
     private void select_one_icon (Gtk.Grid color_row, Gtk.Grid icon_row) {
-        var has_color_icons = color_row.get_first_child () is Gtk.ToggleButton;
+        var has_color_icons = color_row.get_first_child () is Adw.Clamp;
         var row = has_color_icons ? color_row : icon_row;
-        var btn = row.get_child_at (1, 0) ?? row.get_first_child ();
-        ((Gtk.ToggleButton) btn).active = true;
+        var clamp = (Adw.Clamp) (row.get_child_at (1, 0) ?? row.get_first_child ());
+        ((Gtk.ToggleButton) clamp.child).active = true;
     }
 }
 


### PR DESCRIPTION
Resolves #12 

I wrapped icons in toggle buttons, tracked the selected one and updated example code snippet accordingly. This also fixes an issue with incorrect snippet for symbolic only icons or those without size 24px, for which the static snippet doesn't work.

Example of using it:

[dynamic-snippet-showcase.webm](https://user-images.githubusercontent.com/5374391/203643843-3fedc582-7ca3-42c9-af0d-1254ffcbc980.webm)
