### PR TITLE
Copy code for code snippet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 build/*
+.flatpak-builder/*

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,7 @@ executable(
     gresource,
     'src/Application.vala',
     'src/CategoryView.vala',
+    'src/IconDetails.vala',
     'src/IconView.vala',
     'src/MainWindow.vala',
     'src/Widgets/IconListRow.vala',

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -29,7 +29,7 @@ public class IconBrowser.App : Gtk.Application {
         var copy_action = new SimpleAction ("copy", null);
 
         add_action (copy_action);
-        set_accels_for_action ("app.copy",  {"<Control>c"});
+        set_accels_for_action ("app.copy", {"<Control>c"});
 
         copy_action.activate.connect (() => {
             ((MainWindow) active_window).copy_code_snippet ();
@@ -67,4 +67,3 @@ public class IconBrowser.App : Gtk.Application {
         return new IconBrowser.App ().run (args);
     }
 }
-

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -26,6 +26,15 @@ public class IconBrowser.App : Gtk.Application {
 
         quit_action.activate.connect (quit);
 
+        var copy_action = new SimpleAction ("copy", null);
+
+        add_action (copy_action);
+        set_accels_for_action ("app.copy",  {"<Control>c"});
+
+        copy_action.activate.connect (() => {
+            ((MainWindow) active_window).copy_code_snippet ();
+        });
+
         var provider = new Gtk.CssProvider ();
         provider.load_from_resource ("/io/elementary/iconbrowser/Application.css");
         Gtk.StyleContext.add_provider_for_display (Gdk.Display.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
@@ -58,3 +67,4 @@ public class IconBrowser.App : Gtk.Application {
         return new IconBrowser.App ().run (args);
     }
 }
+

--- a/src/CategoryView.vala
+++ b/src/CategoryView.vala
@@ -8,6 +8,9 @@ public class CategoryView : Gtk.Box {
 
     public Gtk.ListBox listbox { get; private set; }
     public Gtk.SearchEntry search_entry { get; private set; }
+    public IconDetails selected_icon { get {return icon_view.selected_icon; } }
+
+    private IconView icon_view;
 
     public enum Category {
         ACTIONS,
@@ -2375,7 +2378,7 @@ public class CategoryView : Gtk.Box {
     };
 
     construct {
-        var icon_view = new IconView ();
+        icon_view = new IconView ();
 
         search_entry = new Gtk.SearchEntry () {
             hexpand = true,

--- a/src/IconDetails.vala
+++ b/src/IconDetails.vala
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2017-2022 elementary, Inc. (https://elementary.io)
+ */
+public class IconDetails : Object {
+    public string full_icon_name { get; construct; }
+    public int size_in_px { get; construct; }
+
+    public IconDetails (string name, int size) {
+        Object (
+            full_icon_name: name,
+            size_in_px: size
+        );
+    }
+
+    public string code_snippet () {
+        return """var icon = new Gtk.Image.from_icon_name ("%s") {
+    pixel_size = %d
+};""".printf (full_icon_name, size_in_px);
+    }
+}

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -13,7 +13,7 @@ public class IconView : Gtk.Box {
             icon_name: "address-book-new",
             description: _("Create a new address book"),
             category: CategoryView.Category.ACTIONS,
-            selected_icon: new IconDetails(
+            selected_icon: new IconDetails (
                 "address-book-new",
                 24
             )
@@ -155,7 +155,9 @@ public class IconView : Gtk.Box {
         notify["selected-icon"].connect (() => {
             var name = selected_icon.full_icon_name;
             var size = selected_icon.size_in_px;
-            source_buffer.text = "var icon = new Gtk.Image.from_icon_name (\"%s\") {\n    pixel_size = %d\n};".printf (name, size);
+            source_buffer.text = """var icon = new Gtk.Image.from_icon_name ("%s") {
+    pixel_size = %d
+};""".printf (name, size);
         });
     }
 
@@ -206,7 +208,7 @@ public class IconView : Gtk.Box {
                 hexpand = true
             };
 
-            var icon_and_label = new Gtk.Grid (){
+            var icon_and_label = new Gtk.Grid () {
                 row_spacing = 12,
                 valign = Gtk.Align.CENTER,
                 margin_top = 4,
@@ -243,7 +245,7 @@ public class IconDetails : Object {
     public string full_icon_name { get; construct; }
     public int size_in_px { get; construct; }
 
-    public IconDetails(string name, int size) {
+    public IconDetails (string name, int size) {
         Object (
             full_icon_name: name,
             size_in_px: size

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -121,14 +121,14 @@ public class IconView : Gtk.Box {
         };
         source_overlay.add_overlay (copy_button);
 
-        var enterLeaveCtrl =  new Gtk.EventControllerMotion ();
-        enterLeaveCtrl.enter.connect (() => {
+        var enter_leave_ctrl = new Gtk.EventControllerMotion ();
+        enter_leave_ctrl.enter.connect (() => {
             copy_button.show ();
         });
-        enterLeaveCtrl.leave.connect (() => {
+        enter_leave_ctrl.leave.connect (() => {
             copy_button.hide ();
         });
-        source_overlay.add_controller (enterLeaveCtrl);
+        source_overlay.add_controller (enter_leave_ctrl);
 
         var content_area = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
             vexpand = true
@@ -260,4 +260,3 @@ public class IconView : Gtk.Box {
         ((Gtk.ToggleButton) btn).active = true;
     }
 }
-

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -112,6 +112,7 @@ public class IconView : Gtk.Box {
 
         var copy_button = new Gtk.Button.from_icon_name ("edit-copy") {
             tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>C"}, _("Copy")),
+            action_name = "app.copy",
             valign = Gtk.Align.START,
             halign = Gtk.Align.END,
             visible = false,
@@ -176,11 +177,7 @@ public class IconView : Gtk.Box {
         });
 
         notify["selected-icon"].connect (() => {
-            var name = selected_icon.full_icon_name;
-            var size = selected_icon.size_in_px;
-            source_buffer.text = """var icon = new Gtk.Image.from_icon_name ("%s") {
-    pixel_size = %d
-};""".printf (name, size);
+            source_buffer.text = selected_icon.code_snippet ();
         });
     }
 
@@ -264,14 +261,3 @@ public class IconView : Gtk.Box {
     }
 }
 
-public class IconDetails : Object {
-    public string full_icon_name { get; construct; }
-    public int size_in_px { get; construct; }
-
-    public IconDetails (string name, int size) {
-        Object (
-            full_icon_name: name,
-            size_in_px: size
-        );
-    }
-}

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -106,6 +106,29 @@ public class IconView : Gtk.Box {
         source_view.add_css_class (Granite.STYLE_CLASS_CARD);
         source_view.add_css_class (Granite.STYLE_CLASS_ROUNDED);
 
+        var source_overlay = new Gtk.Overlay () {
+            child = source_view
+        };
+
+        var copy_button = new Gtk.Button.from_icon_name ("edit-copy") {
+            tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>C"}, _("Copy")),
+            valign = Gtk.Align.START,
+            halign = Gtk.Align.END,
+            visible = false,
+            margin_top = 8,
+            margin_end = 8
+        };
+        source_overlay.add_overlay (copy_button);
+
+        var enterLeaveCtrl =  new Gtk.EventControllerMotion ();
+        enterLeaveCtrl.enter.connect (() => {
+            copy_button.show ();
+        });
+        enterLeaveCtrl.leave.connect (() => {
+            copy_button.hide ();
+        });
+        source_overlay.add_controller (enterLeaveCtrl);
+
         var content_area = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
             vexpand = true
         };
@@ -115,7 +138,7 @@ public class IconView : Gtk.Box {
         content_area.append (symbolic_title);
         content_area.append (symbolic_row);
         content_area.append (snippet_title);
-        content_area.append (source_view);
+        content_area.append (source_overlay);
 
         var scrolled = new Gtk.ScrolledWindow () {
             child = content_area,

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -114,6 +114,13 @@ public class IconBrowser.MainWindow : Gtk.ApplicationWindow {
         });
     }
 
+    public void copy_code_snippet () {
+        var snippet = category_view.selected_icon.code_snippet ();
+        var display = Gdk.Display.get_default ();
+        var clipboard = display.get_clipboard ();
+        clipboard.set_text (snippet);
+    }
+
     [CCode (instance_pos = -1)]
     private bool filter_function (Gtk.ListBoxRow row) {
         if (category_view.search_entry.text == "") {


### PR DESCRIPTION
Resolves #5 

I introduced an action for copying the code snippet. Hovering over snippet reveals a copy button which can also be used to trigger the action. Button helps with discovering the feature, and global action helps with keyboard focused workflows.

Example of using this:

[copy-demo.webm](https://user-images.githubusercontent.com/5374391/205501928-b297c217-bec4-4f00-b314-952c8145fc83.webm)

I'll mark this as draft, as it builds upon the selected icon details I introduced in #29, which is currently under review. Any changes to that PR might impact this one too.