### PR TITLE
Flatpak: Use embeded gtksourceview from SDK instead of manual

### DIFF
--- a/io.elementary.iconbrowser.yml
+++ b/io.elementary.iconbrowser.yml
@@ -9,12 +9,6 @@ finish-args:
   - '--socket=wayland'
   - '--device=dri'
 modules:
-  - name: gtksourceview
-    buildsystem: meson
-    sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/gtksourceview.git
-        tag: '5.4.0'
   - name: iconbrowser
     buildsystem: meson
     sources:


### PR DESCRIPTION
Our runtime now comes with gtksourceview 5.8.0, so we no longer need to install 5.4.0 manually:

```
Run-time dependency gtksourceview-5 found: YES 5.8.0
```