### PR TITLE
meson: Use newer syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You'll need the following dependencies to build:
 * libgranite-7-dev
 * libgtk-4-dev
 * libgtksourceview-5-dev
-* meson (>= 0.57)
+* meson
 * valac
 
 Run `meson build` to configure the build environment and then change to the build directory and run `ninja` to build

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You'll need the following dependencies to build:
 * libgranite-7-dev
 * libgtk-4-dev
 * libgtksourceview-5-dev
-* meson
+* meson (>= 0.57)
 * valac
 
 Run `meson build` to configure the build environment and then change to the build directory and run `ninja` to build

--- a/data/meson.build
+++ b/data/meson.build
@@ -2,36 +2,36 @@ icon_sizes = ['16', '24', '32', '48', '64', '128']
 
 foreach i : icon_sizes
     install_data(
-        join_paths('icons', i + '.svg'),
-        install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i, 'apps'),
+        'icons' / i + '.svg',
+        install_dir: get_option('datadir') / 'icons' / 'hicolor' / i + 'x' + i / 'apps',
         rename: meson.project_name() + '.svg'
     )
     install_data(
-        join_paths('icons', i + '.svg'),
-        install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i + '@2', 'apps'),
+        'icons' / i + '.svg',
+        install_dir: get_option('datadir') / 'icons' / 'hicolor' / i + 'x' + i + '@2' / 'apps',
         rename: meson.project_name() + '.svg'
     )
 endforeach
 
 install_data(
     'iconbrowser.gschema.xml',
-    install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas'),
+    install_dir: get_option('datadir') / 'glib-2.0' / 'schemas',
     rename: meson.project_name() + '.gschema.xml'
 )
 
 i18n.merge_file(
     input: 'iconbrowser.desktop.in',
     output: meson.project_name() + '.desktop',
-    po_dir: join_paths(meson.source_root(), 'po', 'extra'),
+    po_dir: meson.project_source_root() / 'po' / 'extra',
     type: 'desktop',
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'applications')
+    install_dir: get_option('datadir') / 'applications'
 )
 
 i18n.merge_file(
     input: 'iconbrowser.appdata.xml.in',
     output: meson.project_name() + '.appdata.xml',
-    po_dir: join_paths(meson.source_root(), 'po', 'extra'),
+    po_dir: meson.project_source_root() / 'po' / 'extra',
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'metainfo')
+    install_dir: get_option('datadir') / 'metainfo'
 )

--- a/meson.build
+++ b/meson.build
@@ -48,4 +48,7 @@ executable(
 subdir('data')
 subdir('po')
 
-gnome.post_install(glib_compile_schemas: true)
+gnome.post_install(
+    glib_compile_schemas: true,
+    gtk_update_icon_cache: true
+)

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,5 +1,5 @@
 i18n.gettext('extra',
-    args: '--directory='+meson.source_root(),
+    args: '--directory=' + meson.project_source_root(),
     install: false,
     preset: 'glib'
 )

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,5 +1,5 @@
 i18n.gettext(meson.project_name(),
-    args: '--directory=' + meson.source_root(),
+    args: '--directory=' + meson.project_source_root(),
     preset: 'glib'
 )
 subdir('extra')


### PR DESCRIPTION
- Use '/' (available since 0.49.0) instead of 'join_paths()'
- Use 'project_source_root()' instead of 'source_root()' (deprecated since 0.56.0)
- Fix icon cache is not updated