### PR TITLE
Update CSS for latest Granite

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -1,3 +1,7 @@
+.titlebar {
+    padding: 0.666rem;
+}
+
 .titlebar + scrolledwindow undershoot.top {
     background:
         linear-gradient(

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -14,6 +14,8 @@ public class IconBrowser.App : Gtk.Application {
     protected override void startup () {
         base.startup ();
 
+        Granite.init ();
+
         Intl.setlocale (LocaleCategory.ALL, "");
         Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
         Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
@@ -25,10 +27,6 @@ public class IconBrowser.App : Gtk.Application {
         set_accels_for_action ("app.quit", {"<Control>q"});
 
         quit_action.activate.connect (quit);
-
-        var provider = new Gtk.CssProvider ();
-        provider.load_from_resource ("/io/elementary/iconbrowser/Application.css");
-        Gtk.StyleContext.add_provider_for_display (Gdk.Display.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
 
     protected override void activate () {

--- a/src/CategoryView.vala
+++ b/src/CategoryView.vala
@@ -2385,7 +2385,6 @@ public class CategoryView : Gtk.Box {
 
         var list_header = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
         list_header.add_css_class ("titlebar");
-        list_header.add_css_class (Granite.STYLE_CLASS_FLAT);
         list_header.append (search_entry);
 
         listbox = new Gtk.ListBox () {

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -54,7 +54,6 @@ public class IconView : Gtk.Box {
             child = header_area
         };
         header_handle.add_css_class ("titlebar");
-        header_handle.add_css_class (Granite.STYLE_CLASS_FLAT);
 
         var color_title = new Granite.HeaderLabel (_("Color Icons"));
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -45,7 +45,6 @@ public class IconBrowser.MainWindow : Gtk.ApplicationWindow {
 
         var sidebar_header = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);
         sidebar_header.add_css_class ("titlebar");
-        sidebar_header.add_css_class (Granite.STYLE_CLASS_FLAT);
         sidebar_header.append (start_window_controls);
 
         var sidebar_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);


### PR DESCRIPTION
* Granite.init () loads `Application.css` automatically
* `titlebar` isn't in the main stylesheet anymore so add our own padding