### PR TITLE
AppData: Add translation info

### DIFF
--- a/data/iconbrowser.appdata.xml.in
+++ b/data/iconbrowser.appdata.xml.in
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2017-2022 elementary, Inc. <contact@elementary.io> -->
+<!-- Copyright 2017-2023 elementary, Inc. <contact@elementary.io> -->
 <component type="desktop-application">
   <id>io.elementary.iconbrowser</id>
   <launchable type="desktop-id">io.elementary.iconbrowser.desktop</launchable>
+  <translation type="gettext">io.elementary.iconbrowser</translation>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
 


### PR DESCRIPTION
Fixes the "May Not Be Translated" warning on AppCenter:

![スクリーンショット 2023-09-01 20 14 37](https://github.com/elementary/iconbrowser/assets/26003928/9653a569-7ac4-46ff-9c41-09684af62483)
