### PR TITLE
Add button to copy code snippet

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -40,3 +40,9 @@
 .content-area {
     padding: 1.33rem;
 }
+
+.copy-button {
+    background: none;
+    border: 1px solid @borders;
+    box-shadow: none;
+}

--- a/data/Application.css
+++ b/data/Application.css
@@ -40,9 +40,3 @@
 .content-area {
     padding: 1.33rem;
 }
-
-.copy-button {
-    background: none;
-    border: 1px solid @borders;
-    box-shadow: none;
-}

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ executable(
     'src/Widgets/IconListRow.vala',
     'src/Widgets/SidebarRow.vala',
     dependencies: [
-        dependency('glib-2.0'),
+        dependency('glib-2.0', version: '>= 2.78'),
         dependency('gobject-2.0'),
         dependency('granite-7'),
         dependency('gtk4'),

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -108,15 +108,16 @@ public class IconView : Gtk.Box {
             valign = START,
             halign = END,
             visible = false,
-            margin_top = 8,
-            margin_end = 8
+            margin_top = 6,
+            margin_end = 6
         };
         copy_button.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
         copy_button.add_css_class ("copy-button");
 
         var copy_visible_controller = new Gtk.EventControllerMotion ();
-        copy_visible_controller.bind_property ("contains-pointer", copy_button, "visible",
-                                                BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE);
+        copy_visible_controller.bind_property (
+            "contains-pointer", copy_button, "visible", DEFAULT | SYNC_CREATE
+        );
 
         var source_overlay = new Gtk.Overlay () {
             child = source_view

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -107,22 +107,29 @@ public class IconView : Gtk.Box {
         copy_button = new Gtk.Button.with_label (_("Copy")) {
             valign = START,
             halign = END,
-            visible = false,
             margin_top = 6,
             margin_end = 6
         };
         copy_button.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
 
-        var copy_visible_controller = new Gtk.EventControllerMotion ();
-        copy_visible_controller.bind_property (
-            "contains-pointer", copy_button, "visible", DEFAULT | SYNC_CREATE
+        var copy_button_revealer = new Gtk.Revealer () {
+            valign = START,
+            halign = END,
+            child = copy_button,
+            transition_type = CROSSFADE,
+            overflow = VISIBLE
+        };
+
+        var copy_button_controller = new Gtk.EventControllerMotion ();
+        copy_button_controller.bind_property (
+            "contains-pointer", copy_button_revealer, "reveal-child", DEFAULT | SYNC_CREATE
         );
 
         var source_overlay = new Gtk.Overlay () {
             child = source_view
         };
-        source_overlay.add_overlay (copy_button);
-        source_overlay.add_controller (copy_visible_controller);
+        source_overlay.add_overlay (copy_button_revealer);
+        source_overlay.add_controller (copy_button_controller);
 
         var content_area = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
             vexpand = true

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -112,7 +112,6 @@ public class IconView : Gtk.Box {
             margin_end = 6
         };
         copy_button.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
-        copy_button.add_css_class ("copy-button");
 
         var copy_visible_controller = new Gtk.EventControllerMotion ();
         copy_visible_controller.bind_property (

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -115,6 +115,8 @@ public class IconView : Gtk.Box {
         copy_button.add_css_class ("copy-button");
 
         var copy_visible_controller = new Gtk.EventControllerMotion ();
+        copy_visible_controller.bind_property ("contains-pointer", copy_button, "visible",
+                                                BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE);
 
         var source_overlay = new Gtk.Overlay () {
             child = source_view
@@ -184,14 +186,6 @@ public class IconView : Gtk.Box {
         });
 
         copy_button.clicked.connect (copy_button_clicked);
-
-        copy_visible_controller.enter.connect (() => {
-            copy_button.visible = true;
-        });
-
-        copy_visible_controller.leave.connect (() => {
-            copy_button.visible = false;
-        });
     }
 
     private void child_activated (Gtk.FlowBoxChild child) {

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -120,16 +120,22 @@ public class IconView : Gtk.Box {
             overflow = VISIBLE
         };
 
-        var copy_button_controller = new Gtk.EventControllerMotion ();
-        copy_button_controller.bind_property (
+        var copy_controller_motion = new Gtk.EventControllerMotion ();
+        copy_controller_motion.bind_property (
             "contains-pointer", copy_button_revealer, "reveal-child", DEFAULT | SYNC_CREATE
+        );
+
+        var copy_controller_focus = new Gtk.EventControllerFocus ();
+        copy_controller_focus.bind_property (
+            "contains-focus", copy_button_revealer, "reveal-child", DEFAULT | SYNC_CREATE
         );
 
         var source_overlay = new Gtk.Overlay () {
             child = source_view
         };
         source_overlay.add_overlay (copy_button_revealer);
-        source_overlay.add_controller (copy_button_controller);
+        source_overlay.add_controller (copy_controller_motion);
+        source_overlay.add_controller (copy_controller_focus);
 
         var content_area = new Gtk.Box (Gtk.Orientation.VERTICAL, 12) {
             vexpand = true

--- a/src/IconView.vala
+++ b/src/IconView.vala
@@ -112,10 +112,11 @@ public class IconView : Gtk.Box {
         };
         copy_button.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
 
+        // Make copy button visible with fade animation when source view contains pointer or focus
         var copy_button_revealer = new Gtk.Revealer () {
+            child = copy_button,
             valign = START,
             halign = END,
-            child = copy_button,
             transition_type = CROSSFADE,
             overflow = VISIBLE
         };


### PR DESCRIPTION
Fixes #5
Closes #31

Differences from the previous PR:

- Use a label instead of the `edit-copy` icon, so that we can also use it to tell users the text being copied
- Do not swallow Ctrl + C in case someone selects some part of the snippet and press that hotkey
  - Now we require GLib >= 2.78 because of `Timeout.add_once ()`

I tried the button to be similar to the one written in the Prior Art of #5, but I'm not familiar with CSS so design feedback is especially appreciated.

![スクリーンショット 2024-08-14 17 44 58](https://github.com/user-attachments/assets/844f567a-7969-44c9-b0d1-61c1c4434389)
